### PR TITLE
[forge-build] cn() utility + base UI components (Button, Input, Card, Badge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.aider*

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+type BadgeVariant = "default" | "secondary" | "outline";
+
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default:
+    "bg-white text-black",
+  secondary:
+    "bg-white/15 text-white",
+  outline:
+    "border border-white/30 text-white bg-transparent",
+};
+
+export function Badge({
+  className,
+  variant = "default",
+  children,
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors",
+        variantClasses[variant],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+type ButtonVariant = "default" | "outline" | "ghost" | "destructive";
+type ButtonSize = "sm" | "md" | "lg";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  default:
+    "bg-white text-black hover:bg-white/90 border border-transparent",
+  outline:
+    "border border-white/30 text-white bg-transparent hover:bg-white/10",
+  ghost:
+    "bg-transparent text-white hover:bg-white/10 border border-transparent",
+  destructive:
+    "bg-red-600 text-white hover:bg-red-700 border border-transparent",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-sm rounded-md",
+  md: "px-4 py-2 text-sm rounded-lg",
+  lg: "px-6 py-3 text-base rounded-lg",
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant = "default",
+      size = "md",
+      disabled,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        disabled={disabled}
+        className={cn(
+          "inline-flex items-center justify-center font-medium transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50",
+          "disabled:pointer-events-none disabled:opacity-50",
+          variantClasses[variant],
+          sizeClasses[size],
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@/lib/utils";
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Card({ className, children, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-white/10 bg-white/5 text-white shadow-sm",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({ className, children, ...props }: CardProps) {
+  return (
+    <div
+      className={cn("flex flex-col gap-1.5 p-6", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CardTitle({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h3
+      className={cn("text-lg font-semibold leading-tight tracking-tight", className)}
+      {...props}
+    >
+      {children}
+    </h3>
+  );
+}
+
+export function CardDescription({
+  className,
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  return (
+    <p
+      className={cn("text-sm text-white/60", className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+export function CardContent({ className, children, ...props }: CardProps) {
+  return (
+    <div
+      className={cn("p-6 pt-0", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CardFooter({ className, children, ...props }: CardProps) {
+  return (
+    <div
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, disabled, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        disabled={disabled}
+        className={cn(
+          "w-full rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-sm text-white",
+          "placeholder:text-white/40",
+          "focus:outline-none focus:ring-2 focus:ring-white/50 focus:border-transparent",
+          "disabled:pointer-events-none disabled:opacity-50",
+          "transition-colors",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Input.displayName = "Input";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Auto-generated by Forge Builder

Implements #1

on-colors",                                                             
                                                                                
        variantClasses[variant],                                                
                                                                                
        className                                                               
                                                                                
      )}                                                                        
                                                                                
      {...props}                                                                
                                                                                
    >                                                                           
                                                                                
      {children}                                                                
                                                                                
    </span>                                                                     
                                                                                
  );                                                                            
                                                                                
}                                                                               
                                                                                

Summary of changes:                                                             

 1 src/lib/utils.ts — Exports cn() using clsx + tailwind-merge. Run npm install 
   clsx tailwind-merge to add the dependencies.                                 
 2 src/components/ui/button.tsx — 'use client' component with forwardRef,       
   supports default | outline | ghost | destructive variants and sm | md | lg   
   sizes. Disabled state handled via Tailwind classes.                          
 3 src/components/ui/input.tsx — 'use client' component with forwardRef,        
   consistent border/focus ring/disabled styling.                               
 4 src/components/ui/card.tsx — Pure Server Components: Card, CardHeader,       
   CardTitle, CardDescription, CardContent, CardFooter. No 'use client' needed. 
 5 src/components/ui/badge.tsx — Server Component with default | secondary |    
   outline variants, suitable for genre tags on DJ profiles.                    

Tokens: 3.7k sent, 1.8k received. Cost: $0.04 message, $0.04 session.

src/lib/utils.ts

src/components/ui/button.tsx

src/components/ui/input.tsx

src/components/ui/card.tsx

src/components/ui/badge.tsx
Applied edit to src/lib/utils.ts
Applied edit to src/components/ui/button.tsx
Applied edit to src/components/ui/badge.tsx
Applied edit to src/components/ui/card.tsx
Applied edit to src/components/ui/input.tsx


---
Built autonomously by [Forge Builder](https://github.com/toolnyc/clubstack) using aider.
Review carefully before merging.
