### PR TITLE
[forge-build] cn() utility + base UI components (Button, Input, Card, Badge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.aider*

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,12 @@
       "dependencies": {
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.98.0",
+        "before": "^0.0.1",
+        "clsx": "^2.1.1",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2552,6 +2555,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/before": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/before/-/before-0.0.1.tgz",
+      "integrity": "sha512-1J5SWbkoVJH9DTALN8igB4p+nPKZzPrJ/HomqBDLpfUvDXCdjdBmBUcH5McZfur0lftVssVU6BZug5NYh87zTw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2712,6 +2724,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6200,6 +6221,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,12 @@
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",
+    "before": "^0.0.1",
+    "clsx": "^2.1.1",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+type BadgeVariant = "default" | "secondary" | "outline";
+
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default:
+    "bg-white text-black",
+  secondary:
+    "bg-white/15 text-white",
+  outline:
+    "border border-white/30 text-white bg-transparent",
+};
+
+function Badge({ className, variant = "default", children, ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        "transition-colors",
+        variantClasses[variant],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+export { Badge };
+export type { BadgeProps };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+type ButtonVariant = "default" | "outline" | "ghost" | "destructive";
+type ButtonSize = "sm" | "md" | "lg";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  default:
+    "bg-white text-black hover:bg-white/90 border border-transparent",
+  outline:
+    "border border-white/30 text-white bg-transparent hover:bg-white/10",
+  ghost:
+    "bg-transparent text-white hover:bg-white/10 border border-transparent",
+  destructive:
+    "bg-red-600 text-white hover:bg-red-700 border border-transparent",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-sm rounded-md",
+  md: "px-4 py-2 text-sm rounded-lg",
+  lg: "px-6 py-3 text-base rounded-lg",
+};
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      className,
+      variant = "default",
+      size = "md",
+      disabled,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        disabled={disabled}
+        className={cn(
+          "inline-flex items-center justify-center font-medium transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50",
+          "disabled:pointer-events-none disabled:opacity-50",
+          variantClasses[variant],
+          sizeClasses[size],
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export { Button };
+export type { ButtonProps };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,94 @@
+import { cn } from "@/lib/utils";
+
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+interface CardDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
+interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+function Card({ className, children, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-white/10 bg-white/5 text-white shadow-sm",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function CardHeader({ className, children, ...props }: CardHeaderProps) {
+  return (
+    <div
+      className={cn("flex flex-col gap-1.5 p-6", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function CardTitle({ className, children, ...props }: CardTitleProps) {
+  return (
+    <h3
+      className={cn("text-lg font-semibold leading-tight tracking-tight", className)}
+      {...props}
+    >
+      {children}
+    </h3>
+  );
+}
+
+function CardDescription({ className, children, ...props }: CardDescriptionProps) {
+  return (
+    <p
+      className={cn("text-sm text-white/60", className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+}
+
+function CardContent({ className, children, ...props }: CardContentProps) {
+  return (
+    <div
+      className={cn("p-6 pt-0", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+function CardFooter({ className, children, ...props }: CardFooterProps) {
+  return (
+    <div
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+};
+export type {
+  CardProps,
+  CardHeaderProps,
+  CardTitleProps,
+  CardDescriptionProps,
+  CardContentProps,
+  CardFooterProps,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { forwardRef } from "react";
+import { cn } from "@/lib/utils";
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, disabled, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        disabled={disabled}
+        className={cn(
+          "w-full rounded-lg border border-white/20 bg-white/5 px-3 py-2",
+          "text-sm text-white placeholder:text-white/40",
+          "transition-colors",
+          "focus:outline-none focus:ring-2 focus:ring-white/50 focus:border-transparent",
+          "disabled:pointer-events-none disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Input.displayName = "Input";
+
+export { Input };
+export type { InputProps };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Auto-generated by Forge Builder

Implements #1

                                                            
    >                                                                           
                                                                                
      {children}                                                                
                                                                                
    </span>                                                                     
                                                                                
  );                                                                            
                                                                                
}                                                                               
                                                                                
                                                                                
                                                                                
export { Badge };                                                               
                                                                                
export type { BadgeProps };                                                     
                                                                                

--------------------------------------------------------------------------------

Summary of changes:                                                             

 • src/lib/utils.ts — exports cn() using clsx + tailwind-merge                  
 • src/components/ui/button.tsx — 'use client', forwardRef, 4 variants (default,
   outline, ghost, destructive), 3 sizes (sm, md, lg), disabled state           
 • src/components/ui/input.tsx — 'use client', forwardRef, focus ring, disabled 
   state                                                                        
 • src/components/ui/card.tsx — Server Component, exports Card, CardHeader,     
   CardTitle, CardDescription, CardContent, CardFooter                          
 • src/components/ui/badge.tsx — Server Component, 3 variants (default,         
   secondary, outline) — designed for genre tags on DJ profiles                 

The styling uses a dark theme (white-on-dark) consistent with an underground    
club aesthetic. Don't forget to run npm install clsx tailwind-merge before      
building.                                                                       

Tokens: 3.8k sent, 2.0k received. Cost: $0.04 message, $0.04 session.

src/lib/utils.ts

src/components/ui/button.tsx

src/components/ui/input.tsx

src/components/ui/card.tsx

src/components/ui/badge.tsx
Applied edit to src/lib/utils.ts
Applied edit to src/components/ui/input.tsx
Applied edit to src/components/ui/button.tsx
Applied edit to src/components/ui/badge.tsx
Applied edit to src/components/ui/card.tsx
Commit 23a9acc feat: add cn() utility and base UI components (Button, Input, 
Card, Badge)


---
Built autonomously by [Forge Builder](https://github.com/toolnyc/clubstack) using aider.
Review carefully before merging.
