### PR TITLE
[forge-build] Site header and footer with navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.aider*

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.98.0",
+        "clsx": "^2.1.1",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -69,6 +71,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1316,6 +1319,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
       "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.98.0",
         "@supabase/functions-js": "2.98.0",
@@ -1660,6 +1664,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1728,6 +1733,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2253,6 +2259,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2596,6 +2603,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2712,6 +2720,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3176,6 +3193,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3361,6 +3379,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5567,6 +5586,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5576,6 +5596,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6202,6 +6223,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -6264,6 +6295,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6426,6 +6458,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6721,6 +6754,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",
+    "clsx": "^2.1.1",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,7 +1,16 @@
+import SiteHeader from "@/components/layout/site-header";
+import SiteFooter from "@/components/layout/site-footer";
+
 export default function MarketingLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <div className="flex min-h-screen flex-col bg-black text-white">
+      <SiteHeader />
+      <main className="flex-1">{children}</main>
+      <SiteFooter />
+    </div>
+  );
 }

--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+export default function SiteFooter() {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="w-full border-t border-white/10 bg-black">
+      <div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-4 py-8 sm:flex-row sm:px-6 lg:px-8">
+        {/* Copyright */}
+        <p className="text-sm text-white/40">
+          &copy; {currentYear} ClubStack. All rights reserved.
+        </p>
+
+        {/* Links */}
+        <nav className="flex items-center gap-6">
+          <Link
+            href="/about"
+            className="text-sm text-white/40 hover:text-white/70 transition-colors"
+          >
+            About
+          </Link>
+          <Link
+            href="/terms"
+            className="text-sm text-white/40 hover:text-white/70 transition-colors"
+          >
+            Terms
+          </Link>
+          <Link
+            href="/privacy"
+            className="text-sm text-white/40 hover:text-white/70 transition-colors"
+          >
+            Privacy
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export default function SiteHeader() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  return (
+    <header
+      className={cn(
+        "sticky top-0 z-50 w-full border-b border-white/10 bg-black/80 backdrop-blur-sm"
+      )}
+    >
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+        {/* Wordmark */}
+        <Link
+          href="/"
+          className="text-xl font-bold tracking-tight text-white hover:text-white/80 transition-colors"
+        >
+          ClubStack
+        </Link>
+
+        {/* Desktop nav */}
+        <nav className="hidden md:flex items-center gap-6">
+          <Link
+            href="/djs"
+            className="text-sm text-white/70 hover:text-white transition-colors"
+          >
+            Browse DJs
+          </Link>
+          <Link
+            href="/for-venues"
+            className="text-sm text-white/70 hover:text-white transition-colors"
+          >
+            For Venues
+          </Link>
+        </nav>
+
+        {/* Desktop right side */}
+        <div className="hidden md:flex items-center gap-3">
+          <Link href="/auth/login">
+            <Button variant="secondary" size="sm">
+              Sign In
+            </Button>
+          </Link>
+        </div>
+
+        {/* Mobile hamburger */}
+        <button
+          type="button"
+          className="md:hidden inline-flex items-center justify-center rounded-md p-2 text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+          aria-label="Toggle menu"
+          aria-expanded={mobileMenuOpen}
+          onClick={() => setMobileMenuOpen((prev) => !prev)}
+        >
+          {mobileMenuOpen ? (
+            // X icon
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          ) : (
+            // Hamburger icon
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            </svg>
+          )}
+        </button>
+      </div>
+
+      {/* Mobile menu */}
+      {mobileMenuOpen && (
+        <div className="md:hidden border-t border-white/10 bg-black/95">
+          <nav className="flex flex-col px-4 py-4 gap-1">
+            <Link
+              href="/djs"
+              className="rounded-md px-3 py-2 text-sm text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              Browse DJs
+            </Link>
+            <Link
+              href="/for-venues"
+              className="rounded-md px-3 py-2 text-sm text-white/70 hover:text-white hover:bg-white/10 transition-colors"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              For Venues
+            </Link>
+            <div className="mt-3 pt-3 border-t border-white/10">
+              <Link href="/auth/login" onClick={() => setMobileMenuOpen(false)}>
+                <Button variant="secondary" size="sm" className="w-full">
+                  Sign In
+                </Button>
+              </Link>
+            </div>
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,45 @@
+import { cn } from "@/lib/utils";
+import { ButtonHTMLAttributes, forwardRef } from "react";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "ghost";
+  size?: "sm" | "md" | "lg";
+  asChild?: boolean;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    { className, variant = "primary", size = "md", children, ...props },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          // Base styles
+          "inline-flex items-center justify-center font-medium rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+          // Variants
+          variant === "primary" &&
+            "bg-white text-black hover:bg-white/90 focus-visible:ring-white",
+          variant === "secondary" &&
+            "bg-white/10 text-white hover:bg-white/20 focus-visible:ring-white",
+          variant === "ghost" &&
+            "bg-transparent text-white hover:bg-white/10 focus-visible:ring-white",
+          // Sizes
+          size === "sm" && "h-8 px-3 text-sm",
+          size === "md" && "h-10 px-4 text-sm",
+          size === "lg" && "h-12 px-6 text-base",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";
+
+export { Button };
+export type { ButtonProps };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Auto-generated by Forge Builder

Implements #2

etingLayout({                                      
   children,                                                                    
 }: {                                                                           
   children: React.ReactNode;                                                   
 }) {                                                                           
+  return (                                                                     
+    <div className="flex min-h-screen flex-col bg-black text-white">           
+    <div className="flex min-h-screen flex-col bg-black text-white">           
+      <SiteHeader />                                                           
+      <main className="flex-1">{children}</main>                               
+      <SiteFooter />                                                           
+    </div>                                                                     
+  );                                                                           
 }                                                                              
                                                                                

Notes:                                                                          

 • src/lib/utils.ts — creates the cn() helper using clsx + tailwind-merge.      
   You'll need to install those dependencies if not already present:            
                                                                                
                                                                                
   npm install clsx tailwind-merge                                              
                                                                                
 • src/components/ui/button.tsx — minimal Button component with primary,        
   secondary, and ghost variants and sm/md/lg sizes, as required by the issue.  
 • src/components/layout/site-header.tsx — 'use client' for the mobile menu     
   toggle state; sticky, blurred dark header with wordmark, nav links, Sign In  
   button, and a hamburger that reveals a mobile drawer.                        
 • src/components/layout/site-footer.tsx — pure Server Component with copyright 
   and placeholder links.                                                       
 • src/app/(marketing)/layout.tsx — wires header and footer into the marketing  
   route group only, leaving (app)/ untouched.                                  

Tokens: 3.6k sent, 2.2k received. Cost: $0.04 message, $0.04 session.

src/lib/utils.ts

src/components/ui/button.tsx

src/components/layout/site-header.tsx

src/components/layout/site-footer.tsx
Applied edit to src/components/layout/site-header.tsx
Applied edit to src/components/ui/button.tsx
Applied edit to src/app/(marketing)/layout.tsx
Applied edit to src/lib/utils.ts
Applied edit to src/components/layout/site-footer.tsx
Commit 47dd24e feat: add site header, footer, Button component, and marketing 
layout


---
Built autonomously by [Forge Builder](https://github.com/toolnyc/clubstack) using aider.
Review carefully before merging.
