### PR TITLE
[forge-build] DJ profiles database schema and migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.aider*

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,7 +28,7 @@ export interface DJProfile {
   id: string;
   user_id: string;
   name: string;
-  slug: string;
+  slug: string; // Must match pattern: ^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$
   bio: string | null;
   genres: Genre[];
   location: string | null;

--- a/supabase/migrations/001_dj_profiles.sql
+++ b/supabase/migrations/001_dj_profiles.sql
@@ -1,0 +1,75 @@
+-- DJ profiles table
+create table dj_profiles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete cascade not null,
+  name text not null,
+  slug text unique not null,
+  bio text,
+  genres text[] not null default '{}',
+  location text,
+  photo_url text,
+  soundcloud_url text,
+  instagram_url text,
+  website_url text,
+  rate_min integer,
+  rate_max integer,
+  is_published boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint slug_format check (slug ~ '^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$'),
+  constraint rate_range check (
+    (rate_min is null or rate_min >= 0) and
+    (rate_max is null or rate_max >= 0) and
+    (rate_min is null or rate_max is null or rate_min <= rate_max)
+  ), -- Allows one rate to be null while the other is set, ensures non-negative rates
+  constraint unique_user_profile unique (user_id)
+);
+
+-- Indexes
+create index idx_dj_profiles_slug on dj_profiles (slug);
+create index idx_dj_profiles_genres on dj_profiles using gin (genres);
+create index idx_dj_profiles_published on dj_profiles (is_published) where is_published = true;
+create index idx_dj_profiles_user_id on dj_profiles (user_id);
+
+-- RLS
+alter table dj_profiles enable row level security;
+
+-- Anyone can read published profiles
+create policy "Published profiles are viewable by everyone"
+  on dj_profiles for select
+  using (is_published = true);
+
+-- Authenticated users can read their own profile (even if unpublished)
+create policy "Users can view own profile"
+  on dj_profiles for select
+  using (auth.uid() = user_id);
+
+-- Users can insert their own profile
+create policy "Users can create own profile"
+  on dj_profiles for insert
+  with check (auth.uid() = user_id);
+
+-- Users can update their own profile
+create policy "Users can update own profile"
+  on dj_profiles for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Users can delete their own profile
+create policy "Users can delete own profile"
+  on dj_profiles for delete
+  using (auth.uid() = user_id);
+
+-- Auto-update updated_at
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger set_updated_at
+  before update on dj_profiles
+  for each row execute function update_updated_at();


### PR DESCRIPTION
## Auto-generated by Forge Builder

Implements #5

                                     
npm run build                                                                   
                                                                                

These changes ensure data integrity and align with business requirements.       

Tokens: 12k sent, 799 received. Cost: $0.0018 message, $0.0061 session.
Applied edit to src/types/index.ts
Applied edit to supabase/migrations/001_dj_profiles.sql
Commit 7ed74da fix: update slug regex comment and add non-negative rate 
constraint

# Fix any errors below, if possible.


## See relevant lines below marked with █.

supabase/migrations/001_dj_profiles.sql:
...⋮...
  2│create table dj_profiles (
  3│  id uuid primary key default gen_random_uuid(),
  4│  user_id uuid references auth.users(id) on delete cascade not null,
  5│  name text not null,
  6│  slug text unique not null,
  7│  bio text,
  8│  genres text[] not null default '{}',
  9│  location text,
 10│  photo_url text,
 11│  soundcloud_url text,
...⋮...
 18│  updated_at timestamptz not null default now(),
 19│
...⋮...
 21│  constraint rate_range check (
 22│    (rate_min is null or rate_min >= 0) and
 23│    (rate_max is null or rate_max >= 0) and
 24│    (rate_min is null or rate_max is null or rate_min <= rate_max)
 25█  ), -- Allows one rate to be null while the other is set, ensures 
non-negative rates
 26│  constraint unique_user_profile unique (user_id)
 27│);
 28│
...⋮...
 33│create index idx_dj_profiles_user_id on dj_profiles (user_id);
 34│
 35│-- RLS
 36█alter table dj_profiles enable row level security;
 37│
 38│-- Anyone can read published profiles
 39█create policy "Published profiles are viewable by everyone"
 40│  on dj_profiles for select
 41│  using (is_published = true);
 42│
 43│-- Authenticated users can read their own profile (even if unpublished)
 44█create policy "Users can view own profile"
 45│  on dj_profiles for select
 46│  using (auth.uid() = user_id);
 47│
 48│-- Users can insert their own profile
 49█create policy "Users can create own profile"
 50│  on dj_profiles for insert
 51█  with check (auth.uid() = user_id);
 52│
 53│-- Users can update their own profile
 54█create policy "Users can update own profile"
 55│  on dj_profiles for update
 56│  using (auth.uid() = user_id)
 57█  with check (auth.uid() = user_id);
 58│
 59│-- Users can delete their own profile
 60█create policy "Users can delete own profile"
 61│  on dj_profiles for delete
 62│  using (auth.uid() = user_id);
 63│
 64│-- Auto-update updated_at
 65│create or replace function update_updated_at()
 66│returns trigger as $$
 67│begin
 68█  new.updated_at = now();
 69│  return new;
 70│end;
 71│$$ language plpgsql;
 72│
...⋮...


Only 3 reflections allowed, stopping.
Summarization failed for model deepseek/deepseek-coder: cannot schedule new futures after shutdown
Summarization failed for model deepseek/deepseek-coder: cannot schedule new futures after shutdown
summarizer unexpectedly failed for all models


---
Built autonomously by [Forge Builder](https://github.com/toolnyc/clubstack) using aider.
Review carefully before merging.
