### PR TITLE
[forge-build] DJ browse/search page with genre filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.aider*

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.98.0",
+        "clsx": "^2.1.1",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -69,6 +71,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1316,6 +1319,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
       "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.98.0",
         "@supabase/functions-js": "2.98.0",
@@ -1660,6 +1664,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1728,6 +1733,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2253,6 +2259,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2596,6 +2603,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2712,6 +2720,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3176,6 +3193,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3361,6 +3379,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5567,6 +5586,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5576,6 +5596,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6202,6 +6223,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -6264,6 +6295,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6426,6 +6458,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6721,6 +6754,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",
+    "clsx": "^2.1.1",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/djs/page.tsx
+++ b/src/app/djs/page.tsx
@@ -1,0 +1,157 @@
+import { Suspense } from "react";
+import { createClient } from "@/lib/supabase/server";
+import { DJCard } from "@/components/dj/dj-card";
+import { GenreFilter } from "@/components/dj/genre-filter";
+import { SearchInput } from "@/components/dj/search-input";
+import { GENRES } from "@/types";
+import type { DJProfile, Genre } from "@/types";
+
+interface DJsPageProps {
+  searchParams: Promise<{
+    q?: string;
+    genre?: string;
+  }>;
+}
+
+async function DJGrid({
+  q,
+  genre,
+}: {
+  q: string | undefined;
+  genre: Genre | undefined;
+}) {
+  const supabase = await createClient();
+
+  let query = supabase
+    .from("dj_profiles")
+    .select("*")
+    .eq("is_published", true)
+    .order("name", { ascending: true });
+
+  if (q) {
+    query = query.or(`name.ilike.%${q}%,location.ilike.%${q}%`);
+  }
+
+  if (genre) {
+    query = query.contains("genres", [genre]);
+  }
+
+  const { data, error } = await query.returns<DJProfile[]>();
+
+  if (error) {
+    return (
+      <p className="text-center text-white/50 py-16">
+        Something went wrong loading DJs. Please try again.
+      </p>
+    );
+  }
+
+  const profiles = data ?? [];
+
+  if (profiles.length === 0) {
+    const hasFilters = q || genre;
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <span className="text-5xl mb-4">🎧</span>
+        <p className="text-lg font-medium text-white/70">
+          {hasFilters
+            ? "No DJs found matching your search"
+            : "No DJs have joined yet. Be the first!"}
+        </p>
+        {hasFilters && (
+          <p className="mt-2 text-sm text-white/40">
+            Try adjusting your filters or search term.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {profiles.map((profile) => (
+        <DJCard key={profile.id} profile={profile} />
+      ))}
+    </div>
+  );
+}
+
+export default async function DJsPage({ searchParams }: DJsPageProps) {
+  const { q, genre } = await searchParams;
+
+  const validGenre =
+    genre && (GENRES as readonly string[]).includes(genre)
+      ? (genre as Genre)
+      : undefined;
+
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="mb-10">
+          <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            Browse DJs
+          </h1>
+          <p className="mt-2 text-white/50">
+            Discover underground talent for your next event.
+          </p>
+        </div>
+
+        {/* Search + Filters — wrapped in Suspense because they use useSearchParams */}
+        <div className="mb-8 space-y-4">
+          <Suspense
+            fallback={
+              <div className="h-10 rounded-xl bg-white/5 animate-pulse" />
+            }
+          >
+            <SearchInput />
+          </Suspense>
+          <Suspense
+            fallback={
+              <div className="h-9 rounded-full bg-white/5 animate-pulse" />
+            }
+          >
+            <GenreFilter />
+          </Suspense>
+        </div>
+
+        {/* Active filter summary */}
+        {(q || validGenre) && (
+          <p className="mb-6 text-sm text-white/40">
+            Filtering by
+            {q && (
+              <>
+                {" "}
+                name/location:{" "}
+                <span className="text-white/70">&ldquo;{q}&rdquo;</span>
+              </>
+            )}
+            {q && validGenre && " and"}
+            {validGenre && (
+              <>
+                {" "}
+                genre: <span className="text-white/70">{validGenre}</span>
+              </>
+            )}
+          </p>
+        )}
+
+        {/* DJ Grid */}
+        <Suspense
+          fallback={
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="aspect-[3/4] rounded-xl bg-white/5 animate-pulse"
+                />
+              ))}
+            </div>
+          }
+        >
+          <DJGrid q={q} genre={validGenre} />
+        </Suspense>
+      </div>
+    </main>
+  );
+}

--- a/src/components/dj/dj-card.tsx
+++ b/src/components/dj/dj-card.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { DJProfile } from "@/types";
+
+interface DJCardProps {
+  profile: DJProfile;
+}
+
+export function DJCard({ profile }: DJCardProps) {
+  const displayGenres = profile.genres.slice(0, 3);
+  const extraGenreCount = profile.genres.length - displayGenres.length;
+
+  return (
+    <Link href={`/djs/${profile.slug}`} className="group block">
+      <Card className="transition-colors duration-200 group-hover:border-white/25 group-hover:bg-white/10">
+        {/* Photo */}
+        <div className="relative aspect-square w-full bg-white/5 overflow-hidden">
+          {profile.photo_url ? (
+            <Image
+              src={profile.photo_url}
+              alt={`${profile.name} photo`}
+              fill
+              className="object-cover transition-transform duration-300 group-hover:scale-105"
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <span className="text-5xl text-white/20 select-none">♪</span>
+            </div>
+          )}
+        </div>
+
+        {/* Info */}
+        <CardContent>
+          <h3 className="font-semibold text-white truncate mb-1">
+            {profile.name}
+          </h3>
+
+          {profile.location && (
+            <p className="text-sm text-white/50 truncate mb-3">
+              {profile.location}
+            </p>
+          )}
+
+          {profile.genres.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {displayGenres.map((genre) => (
+                <Badge key={genre}>{genre}</Badge>
+              ))}
+              {extraGenreCount > 0 && (
+                <Badge className="bg-white/5 text-white/40">
+                  +{extraGenreCount}
+                </Badge>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/components/dj/genre-filter.tsx
+++ b/src/components/dj/genre-filter.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { GENRES } from "@/types";
+import { cn } from "@/lib/utils";
+
+export function GenreFilter() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const activeGenre = searchParams.get("genre");
+
+  function handleGenreClick(genre: string | null) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (genre) {
+      params.set("genre", genre);
+    } else {
+      params.delete("genre");
+    }
+    params.delete("page");
+    router.push(`${pathname}?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <button
+        onClick={() => handleGenreClick(null)}
+        className={cn(
+          "shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors duration-150",
+          !activeGenre
+            ? "bg-white text-black"
+            : "bg-white/10 text-white/70 hover:bg-white/20 hover:text-white"
+        )}
+      >
+        All
+      </button>
+
+      {GENRES.map((genre) => (
+        <button
+          key={genre}
+          onClick={() => handleGenreClick(genre)}
+          className={cn(
+            "shrink-0 rounded-full px-4 py-1.5 text-sm font-medium transition-colors duration-150",
+            activeGenre === genre
+              ? "bg-white text-black"
+              : "bg-white/10 text-white/70 hover:bg-white/20 hover:text-white"
+          )}
+        >
+          {genre}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/dj/search-input.tsx
+++ b/src/components/dj/search-input.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useCallback, useTransition } from "react";
+import { cn } from "@/lib/utils";
+
+export function SearchInput() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      const params = new URLSearchParams(searchParams.toString());
+      if (value) {
+        params.set("q", value);
+      } else {
+        params.delete("q");
+      }
+      params.delete("page");
+      startTransition(() => {
+        router.push(`${pathname}?${params.toString()}`);
+      });
+    },
+    [router, pathname, searchParams]
+  );
+
+  return (
+    <div className="relative">
+      <svg
+        className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/40"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z"
+        />
+      </svg>
+      <input
+        type="search"
+        placeholder="Search DJs by name or location…"
+        defaultValue={searchParams.get("q") ?? ""}
+        onChange={handleChange}
+        className={cn(
+          "w-full rounded-xl border border-white/10 bg-white/5",
+          "py-2.5 pl-10 pr-4 text-sm text-white placeholder:text-white/40",
+          "focus:border-white/30 focus:outline-none",
+          "transition-colors duration-150",
+          isPending && "opacity-70"
+        )}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@/lib/utils";
+
+interface BadgeProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function Badge({ className, children }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        "bg-white/10 text-white/80",
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils";
+
+interface CardProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function Card({ className, children }: CardProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-white/10 bg-white/5 overflow-hidden",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CardContent({ className, children }: CardProps) {
+  return <div className={cn("p-4", className)}>{children}</div>;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Auto-generated by Forge Builder

Implements #8

       
    </main>                                                                     
                                                                                
  );                                                                            
                                                                                
}                                                                               
                                                                                

After creating these files, run:                                                

                                                                                
                                                                                
npm install clsx tailwind-merge                                                 
                                                                                
npm run build                                                                   
                                                                                

Summary of what was created:                                                    

 • src/lib/utils.ts — cn() helper using clsx + tailwind-merge                   
 • src/components/ui/card.tsx — Card + CardContent primitives                   
 • src/components/ui/badge.tsx — Badge primitive                                
 • src/components/dj/dj-card.tsx — Server Component; photo with placeholder,    
   name, location, truncated genre badges, links to /djs/[slug]                 
 • src/components/dj/genre-filter.tsx — Client Component; horizontally          
   scrollable pill buttons, updates URL search params                           
 • src/components/dj/search-input.tsx — Client Component; updates URL search    
   params on change with useTransition for pending state                        
 • src/app/djs/page.tsx — Async Server Component; reads searchParams, queries   
   Supabase with ilike + contains, renders grid with empty states and Suspense  
   skeletons                                                                    

Tokens: 7.7k sent, 3.5k received. Cost: $0.07 message, $0.14 session.

src/lib/utils.ts

src/components/ui/card.tsx

src/components/ui/badge.tsx

src/components/dj/dj-card.tsx

src/components/dj/genre-filter.tsx

src/components/dj/search-input.tsx

src/app/djs/page.tsx
Applied edit to src/lib/utils.ts
Applied edit to src/components/dj/dj-card.tsx
Applied edit to src/components/ui/card.tsx
Applied edit to src/components/dj/search-input.tsx
Applied edit to src/components/ui/badge.tsx
Applied edit to src/app/djs/page.tsx
Applied edit to src/components/dj/genre-filter.tsx
Commit 7eb0b64 feat: implement DJ browse/search page with genre filtering
Summarization failed for model claude-sonnet-4-6: cannot schedule new futures after shutdown
Summarization failed for model claude-sonnet-4-6: cannot schedule new futures after shutdown
summarizer unexpectedly failed for all models


---
Built autonomously by [Forge Builder](https://github.com/toolnyc/clubstack) using aider.
Review carefully before merging.
